### PR TITLE
systemd.daemon.notify: do not swallow exceptions

### DIFF
--- a/cysystemd/daemon.py
+++ b/cysystemd/daemon.py
@@ -53,10 +53,7 @@ def notify(notification, value=None, unset_environment=False):
 
     log.debug("Send %r into systemd", line)
 
-    try:
-        return sd_notify(line, unset_environment)
-    except Exception as e:
-        log.error("%s", e)
+    return sd_notify(line, unset_environment)
 
 
 __all__ = ('notify', 'Notification')


### PR DESCRIPTION
If there's a RuntimeError in this procedure, I want to be able to catch it.