### PR TITLE
Send facility propetry's value not name

### DIFF
--- a/cysystemd/journal.py
+++ b/cysystemd/journal.py
@@ -92,7 +92,7 @@ class JournaldLogHandler(logging.Handler):
         """
         logging.Handler.__init__(self)
         self.__identifier = identifier
-        self.__facility = Facility(int(facility))
+        self.__facility = Facility(int(facility)).value
 
     @staticmethod
     def _to_microsecond(ts):


### PR DESCRIPTION
A message which is emitted from `JournaldLogHandler` has facility field filled up with enum name instead of its value (e.g. `"Facility.DAEMON"` instead of `"3"`. Thus, journald ignores this field when it forwards messages to syslog.