### PR TITLE
Modernize Debian instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,16 +42,17 @@ Installation from sources
 
 You should install systemd headers
 
-For debian users:
-
+For Debian/Ubuntu users:
 
 .. code-block:: bash
 
-    apt-get install build-essential \
-        libsystemd-journal-dev \
-        libsystemd-daemon-dev \
-        libsystemd-dev
+    apt install build-essential libsystemd-dev
 
+On older versions of Debian/Ubuntu, you might also need to install:
+
+.. code-block:: bash
+
+    apt install libsystemd-daemon-dev libsystemd-journal-dev
 
 For CentOS/RHEL
 


### PR DESCRIPTION
* The libsystemd-daemon-dev and libsystemd-journal-dev packages were
  removed from Debian 10 "buster", released July 2019. Since then,
  installing libsystemd-dev is sufficient. List the other packages
  separately.

* Around the same time, `apt` became the preferred front-end for package
  management. Suggest it in the examples.

* Note these instructions probably work on Ubuntu too.