### PR TITLE
Serialize journal priority as int when possible

### DIFF
--- a/cysystemd/_journal.pyx
+++ b/cysystemd/_journal.pyx
@@ -37,6 +37,9 @@ cpdef _send(kwargs):
                 'Key name must be consist only of characters, '
                 'numbers and underscores'
             )
+        elif key == 'PRIORITY' and isinstance(value, int):
+            # Serialize int subclasses (like IntEnum) to plain int
+            value = int(value)
 
         items.append((key, value))
 


### PR DESCRIPTION
This fixes #46, and lets the example in the README work as advertised,
in a way that tries to strike a good balance between being generic and
not breaking other use cases: we always serialize int subclasses as
ints.

* This lets the example work because journal.Priority is IntEnum, but it
  would work just as well for IntEnums in other libraries.

* It still lets callers pass in custom strings or other objects if they
  want, possibly including regular Enums.