### PR TITLE
Sanitize field names from Mappings is JournaldLogHandler

### DIFF
--- a/cysystemd/journal.py
+++ b/cysystemd/journal.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import traceback
 import uuid
 from enum import IntEnum, unique
@@ -71,6 +72,7 @@ def write(message, priority=Priority.INFO):
 
 
 class JournaldLogHandler(logging.Handler):
+    FIELD_BADCHAR_RE = re.compile(r'\W')
     LEVELS = {
         logging.CRITICAL: Priority.CRITICAL.value,
         logging.FATAL: Priority.PANIC.value,
@@ -167,6 +169,7 @@ class JournaldLogHandler(logging.Handler):
         args = data.pop("args", [])
         if isinstance(args, Mapping):
             for key, value in args.items():
+                key = self.FIELD_BADCHAR_RE.sub('_', key)
                 data["argument_%s" % key] = value
         else:
             for idx, item in enumerate(args):


### PR DESCRIPTION
If the caller is using field names that journald can't accept for any
reason, transform those into something journald can accept, and then log
it that way. Fixes #35.

With this change, there is a possibility that multiple keys will be
sanitized to the same journald-safe string, and only some of them will
be logged. But this should be rare, and if it does happen, probably the
user is using this calling convention for log message keyword
formatting, and isn't so concerned with having their data logged as
journal fields. So I think keeping the implementation as simple as
possible is more valuable than worrying about that corner case.