### PR TITLE
Fix Rule.add_filter

### DIFF
--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -494,8 +494,9 @@ cdef class JournalReader:
                 elif operand == MatchOperation.AND:
                     result = sd_journal_add_conjunction(self.context)
                     check_error_code(result)
-
-                raise ValueError('Invalid operation')
+                    
+                else:
+                    raise ValueError('Invalid operation')
 
     def clear_filter(self):
         sd_journal_flush_matches(self.context)

--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -489,11 +489,11 @@ cdef class JournalReader:
 
                 if operand == MatchOperation.OR:
                     result = sd_journal_add_disjunction(self.context)
-                    return check_error_code(result)
+                    check_error_code(result)
 
                 elif operand == MatchOperation.AND:
                     result = sd_journal_add_conjunction(self.context)
-                    return check_error_code(result)
+                    check_error_code(result)
 
                 raise ValueError('Invalid operation')
 


### PR DESCRIPTION
The current implementation of `Rule.add_filter` only adds the first rule before returning; this doesn't seem like the intended behaviour.

This PR makes it so that all rules are duly added.