### PR TITLE
A few small fixes in cysystemd.reader

### DIFF
--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -265,8 +265,9 @@ cdef class JournalEntry:
     cpdef uint64_t get_monotonic_usec(self):
         return self.monotonic_usec
 
+    @property
     def boot_id(self):
-        return self.boot_id
+        return self.__boot_uuid
 
     @property
     def date(self):

--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -245,9 +245,7 @@ cdef class JournalEntry:
 
         self._data = self.__data
         self.__boot_uuid = UUID(bytes=self.__boot_id.bytes[:16])
-        date = datetime.utcfromtimestamp(self.get_realtime_sec())
-        date.replace(tzinfo=timezone.utc)
-        self.__date = date
+        self.__date = datetime.fromtimestamp(self.get_realtime_sec(), timezone.utc)
 
     @property
     def cursor(self):

--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 from contextlib import contextmanager
 from errno import errorcode
-from enum import IntEnum
+from enum import IntEnum, IntFlag
 
 
 log = logging.getLogger(__name__)
@@ -135,7 +135,7 @@ def check_error_code(int code):
 
 
 
-class JournalOpenMode(IntEnum):
+class JournalOpenMode(IntFlag):
     LOCAL_ONLY = SD_JOURNAL_LOCAL_ONLY
     RUNTIME_ONLY = SD_JOURNAL_RUNTIME_ONLY
     SYSTEM = SD_JOURNAL_SYSTEM


### PR DESCRIPTION
This PR includes three minor fixes to `cysstemd.reader`.   (Let me know if you'd like me to split it into separate PRs.)

#### Fix JournalEntry.date

Sets the `.tzinfo` attribute of the `datetime` returned by the `JournalEntry.date` attribute.  This fixes #60.

#### Fix JournalEntry.boot_id

Fixes the `JournalEntry.boot_id` method (and converts it to a property). It was totally broken — it just returned itself (a method instance).

#### Fix JournalOpenMode

Fixes `JournalOpenMode` making it an `IntFlag` rather than an `IntEnum`.  It should be a flag — that is, it members can be bit-ORed with each other.   The `IntEnum` does not allow that.  In particular, I would like to be able to pass `flags=0` to `JournalReader.open` in order to be able to implement the same functionality as passing the `--merge` option to `journalctl`