### PR TITLE
Simplify async journal reader implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ linux_wheel:
 		-v $(shell pwd):/app/src \
 		-v $(shell pwd)/dist:/app/dst \
 		--entrypoint /bin/bash \
-		quay.io/pypa/manylinux_2_28_x86_64 \
+		quay.io/pypa/manylinux_2_34_x86_64 \
 		/app/src/scripts/make-wheels.sh
 
 	docker run -it --rm \
@@ -20,5 +20,5 @@ linux_wheel:
 		-v $(shell pwd)/dist:/app/dst \
 		--platform=linux/arm64 \
 		--entrypoint /bin/bash \
-		quay.io/pypa/manylinux_2_28_aarch64 \
+		quay.io/pypa/manylinux_2_34_aarch64 \
 		/app/src/scripts/make-wheels.sh

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Method `wait()` use epoll on journald file descriptor.
 import asyncio
 import json
 
-from cysystemd.reader import JournalOpenMode, JournalEvent
+from cysystemd.reader import JournalOpenMode
 from cysystemd.async_reader import AsyncJournalReader
 
 
@@ -269,23 +269,8 @@ async def main():
     await reader.open(JournalOpenMode.SYSTEM)
     await reader.seek_tail()
 
-    while True:
-        event = await reader.wait()
-        if event == JournalEvent.APPEND:
-            async for record in reader:
-                print(
-                    json.dumps(
-                        record.data,
-                        indent=1,
-                        sort_keys=True
-                    )
-                )
-        elif event == JournalEvent.INVALIDATE:
-            # Journal files were rotated or removed have to recreate reader
-            reader = AsyncJournalReader()
-            await reader.open(JournalOpenMode.SYSTEM)
-            await reader.seek_head()
-
+    async for record in reader:
+        print(json.dumps(record.data, indent=1, sort_keys=True))
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -6,7 +6,32 @@ Python systemd wrapper using Cython.
 
 ## Installation
 
-### Important: System Requirements
+### About Binary Wheels Distribution
+
+Historically, `cysystemd` was not distributed via wheels due to systemd versioning challenges.
+While the `libsystemd` headers remain relatively stable, the ABI can vary between different OS versions and
+distributions.
+Previous attempts to distribute wheels resulted in compatibility issues across different Linux systems.
+Currently, we use the `manylinux_2_34` format for wheel distribution, which bundles the necessary shared objects
+(.so files) required for operation.
+
+This approach should provide compatibility with modern systemd installations.
+
+**However, if you encounter any compatibility issues, we strongly recommend installing the package from
+source code instead.**
+
+```bash
+pip install --no-binary=:all: cysystemd
+```
+
+### Installation from PyPI
+
+Once the system dependencies are installed, you can install cysystemd:
+```shell
+pip install cysystemd
+```
+
+### Installation from Source
 
 **You must install the systemd development headers (libsystemd) before installation!** Without these headers, the
 installation will fail.
@@ -26,32 +51,6 @@ For CentOS/RHEL:
 ```shell
 yum install gcc systemd-devel
 ```
-
-### Installation from PyPI
-
-Once the system dependencies are installed, you can install cysystemd:
-```shell
-pip install cysystemd
-```
-
-## Why binary wheels are no longer distributed
-
-While we previously distributed binary wheels, we've discontinued this practice due to systemd ABI compatibility issues
-across different Linux distributions. Here's why:
-
-* Different Linux distributions ship different versions of systemd with varying ABI
-  (Application Binary Interface)
-* Even though the systemd headers (`libsystemd-dev`) remain relatively stable, the underlying ABI can change
-  between systemd versions
-* A wheel built against one version of systemd may not work correctly on systems with different systemd versions
-* Attempts to distribute pre-built wheels resulted in runtime compatibility issues across different Linux distributions
-  and systemd versions
-
-For these reasons, it's safer and more reliable to build cysystemd from source on your target system, ensuring proper
-compatibility with your system's specific systemd version. This is why we recommend installing from source using the
-build dependencies specified above.
-
-Based on the changes in the diff, I'll help write a BREAKING CHANGES article detailing the significant changes in version 2.0.0:
 
 # BREAKING CHANGES in v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -4,48 +4,87 @@
 
 Python systemd wrapper using Cython.
 
-
 ## Installation
 
-All packages available on `github releases <https://github.com/mosquito/cysystemd/releases>`_.
+### Important: System Requirements
 
-### Installation from binary wheels
-
-* wheels is now available for Python 3.8, 3.9, 3.10, 3.11, 3.12
-  for `x86_64` and `arm64`
-
-```shell
-python3.10 -m pip install \
-  https://github.com/mosquito/cysystemd/releases/download/1.6.2/cysystemd-1.6.2-cp310-cp310-linux_x86_64.whl
-```
-
-### Installation from sources
-
-You **must** install **systemd headers**
+**You must install the systemd development headers (libsystemd) before installation!** Without these headers, the
+installation will fail.
 
 For Debian/Ubuntu users:
-
 ```shell
 apt install build-essential libsystemd-dev
 ```
 
-On older versions of Debian/Ubuntu, you might also need to install:
+On older versions of Debian/Ubuntu, you might also need:
 
 ```shell
 apt install libsystemd-daemon-dev libsystemd-journal-dev
 ```
 
-For CentOS/RHEL
-
+For CentOS/RHEL:
 ```shell
 yum install gcc systemd-devel
 ```
 
-And install it from pypi
+### Installation from PyPI
 
+Once the system dependencies are installed, you can install cysystemd:
 ```shell
 pip install cysystemd
 ```
+
+## Why binary wheels are no longer distributed
+
+While we previously distributed binary wheels, we've discontinued this practice due to systemd ABI compatibility issues
+across different Linux distributions. Here's why:
+
+* Different Linux distributions ship different versions of systemd with varying ABI
+  (Application Binary Interface)
+* Even though the systemd headers (`libsystemd-dev`) remain relatively stable, the underlying ABI can change
+  between systemd versions
+* A wheel built against one version of systemd may not work correctly on systems with different systemd versions
+* Attempts to distribute pre-built wheels resulted in runtime compatibility issues across different Linux distributions
+  and systemd versions
+
+For these reasons, it's safer and more reliable to build cysystemd from source on your target system, ensuring proper
+compatibility with your system's specific systemd version. This is why we recommend installing from source using the
+build dependencies specified above.
+
+Based on the changes in the diff, I'll help write a BREAKING CHANGES article detailing the significant changes in version 2.0.0:
+
+# BREAKING CHANGES in v2.0.0
+
+## AsyncJournalReader Changes
+1. Major refactoring of the AsyncJournalReader iterator implementation:
+   * Removed internal queue and threading-based implementation
+   * Now uses direct async iteration through journal events
+   * More reliable handling of journal invalidation events
+   * Simpler and more efficient implementation
+
+2. `wait()` method now returns `JournalEvent` instead of boolean
+   * Returns specific event type (`JournalEvent.APPEND`, `JournalEvent.INVALIDATE`, `JournalEvent.NOP`)
+   * Better error handling and event processing
+
+## Type Annotations
+* Added comprehensive type hints throughout the codebase
+* Added return type annotations for all public methods
+* Enhanced IDE support and code documentation
+
+## API Behavior Changes
+* `seek_tail()` now automatically calls `previous()` to ensure cursor is positioned correctly
+* Improved error handling and validation in various methods
+* More consistent return types across the API
+
+## Python Support
+* Added support for Python 3.13
+* Maintained support for Python 3.8-3.12
+
+## Dependency Changes
+* Requires latest libsystemd development headers
+* Binary wheels are no longer distributed (see "Why binary wheels are no longer distributed" above)
+
+Please ensure your code is updated to handle these changes when upgrading to version 2.0.0.
 
 ## Usage examples
 

--- a/cysystemd/__init__.py
+++ b/cysystemd/__init__.py
@@ -1,5 +1,5 @@
 package_info = "systemd wrapper in Cython"
-version_info = (1, 6, 3)
+version_info = (2, 0, 0)
 
 
 author_info = (("Dmitry Orlov", "me@mosquito.su"),)

--- a/cysystemd/async_reader.py
+++ b/cysystemd/async_reader.py
@@ -9,7 +9,7 @@ from typing import Callable, TypeVar
 from uuid import UUID
 from weakref import finalize
 
-from .reader import JournalOpenMode, JournalReader, JournalEntry
+from .reader import JournalOpenMode, JournalReader, JournalEntry, JournalEvent
 
 
 A = TypeVar("A")
@@ -37,7 +37,7 @@ class AsyncJournalReader(Base):
         self.__wait_lock = asyncio.Lock()
         self.__iterator = None
 
-    async def wait(self):
+    async def wait(self) -> JournalEvent:
         async with self.__wait_lock:
             loop = self._loop
             reader = self.__reader
@@ -50,9 +50,7 @@ class AsyncJournalReader(Base):
             finally:
                 loop.remove_reader(reader.fd)
 
-            reader.process_events()
-
-        return True
+            return reader.process_events()
 
     def open(self, flags=JournalOpenMode.CURRENT_USER):
         self.__flags = flags

--- a/cysystemd/async_reader.py
+++ b/cysystemd/async_reader.py
@@ -3,7 +3,8 @@ import logging
 
 from collections.abc import AsyncIterator
 from functools import partial
-from typing import Callable, TypeVar
+from pathlib import Path
+from typing import Callable, TypeVar, Union
 from uuid import UUID
 
 from .reader import JournalOpenMode, JournalReader, JournalEntry, JournalEvent

--- a/cysystemd/async_reader.py
+++ b/cysystemd/async_reader.py
@@ -36,12 +36,13 @@ class AsyncJournalReader(Base):
         async with self.__wait_lock:
             loop = self._loop
             reader = self.__reader
-            future = loop.create_future()
+            # Use asyncio.Event to handle multiple set calls without issues
+            event = asyncio.Event()
 
-            loop.add_reader(reader.fd, future.set_result, None)
+            loop.add_reader(reader.fd, event.set)
 
             try:
-                await future
+                await event.wait()
             finally:
                 loop.remove_reader(reader.fd)
 

--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -264,18 +264,18 @@ cdef class JournalEntry:
     def cursor(self) -> bytes:
         return self.cursor
 
-    cpdef double get_realtime_sec(self) -> float:
+    cpdef double get_realtime_sec(self):
         cdef double result = self.realtime_usec / 1000000.
         return result
 
-    cpdef double get_monotonic_sec(self) -> float:
+    cpdef double get_monotonic_sec(self):
         cdef double result = self.monotonic_usec / 1000000.
         return self.monotonic_usec / 1000000.
 
-    cpdef uint64_t get_realtime_usec(self) -> int:
+    cpdef uint64_t get_realtime_usec(self):
         return self.realtime_usec
 
-    cpdef uint64_t get_monotonic_usec(self) -> int:
+    cpdef uint64_t get_monotonic_usec(self):
         return self.monotonic_usec
 
     @property
@@ -441,7 +441,7 @@ cdef class JournalReader:
         check_error_code(result)
         return True
 
-    cpdef wait(self, uint32_t timeout = WAIT_MAX_TIME) -> JournalEvent:
+    cpdef wait(self, uint32_t timeout = WAIT_MAX_TIME):
         cdef uint64_t timeout_usec = timeout * 1000000
         cdef int result
 

--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -1,4 +1,5 @@
 #cython: unraisable_tracebacks=True
+from typing import Iterator, Tuple
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.stdint cimport uint8_t, uint32_t, uint64_t
@@ -67,48 +68,48 @@ cdef class Rule:
         self._operand = MatchOperation.AND
 
     @property
-    def expression(self):
+    def expression(self) -> bytes:
         return self._expression
 
     @property
-    def child(self):
+    def child(self) -> Rule:
         return self._child
 
     @child.setter
-    def child(self, Rule child):
+    def child(self, Rule child) -> None:
         self._child = child
 
     @property
-    def root(self):
+    def root(self) -> Rule:
         return self._root
 
     @root.setter
-    def root(self, Rule root):
+    def root(self, Rule root) -> None:
         self._root = root
 
     @property
-    def operand(self):
+    def operand(self) -> MatchOperation:
         return self._operand
 
     @operand.setter
-    def operand(self, uint8_t op):
+    def operand(self, uint8_t op) -> None:
         self._operand = MatchOperation(op)
 
-    def __and__(self, Rule other):
+    def __and__(self, Rule other) -> Rule:
         self.operand = MatchOperation.AND
         self.child = other
         other.root = self.root
 
         return other
 
-    def __or__(self, Rule other):
+    def __or__(self, Rule other) -> Rule:
         self.operand = MatchOperation.OR
         self.child = other
         other.root = self.root
 
         return other
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         ret = []
         for opcode, exp in self:
             ret.append("%r" % exp.decode())
@@ -116,7 +117,7 @@ cdef class Rule:
 
         return 'Rule(%r)' % ' '.join(ret[:-1])
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Tuple[MatchOperation, bytes]]:
         rule = self.root
 
         while rule is not None:
@@ -124,7 +125,7 @@ cdef class Rule:
             rule = rule.child
 
 
-def check_error_code(int code):
+def check_error_code(int code) -> int:
     if code >= 0:
         return code
 
@@ -143,7 +144,7 @@ class JournalOpenMode(IntFlag):
     CURRENT_USER = SD_JOURNAL_CURRENT_USER
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, value) -> 'JournalOpenMode':
         if value == SD_JOURNAL_SYSTEM_ONLY:
             warnings.warn(
                 "The JournalOpenMode.SYSTEM_ONLY is deprecated and the alias of "
@@ -162,7 +163,7 @@ cdef enum READER_STATE:
     READER_NULL,
 
 
-cdef str _check_dir_path(object path):
+cdef str _check_dir_path(object path) -> str:
     path = str(path)
 
     if not os.path.exists(path):
@@ -184,7 +185,7 @@ cdef str _check_dir_path(object path):
     return path
 
 
-cdef str _check_file_path(object path):
+cdef str _check_file_path(object path) -> str:
     path = str(path)
 
     if not os.path.exists(path):
@@ -260,42 +261,42 @@ cdef class JournalEntry:
         self.__date = datetime.fromtimestamp(self.get_realtime_sec(), timezone.utc)
 
     @property
-    def cursor(self):
+    def cursor(self) -> bytes:
         return self.cursor
 
-    cpdef double get_realtime_sec(self):
+    cpdef double get_realtime_sec(self) -> float:
         cdef double result = self.realtime_usec / 1000000.
         return result
 
-    cpdef double get_monotonic_sec(self):
+    cpdef double get_monotonic_sec(self) -> float:
         cdef double result = self.monotonic_usec / 1000000.
         return self.monotonic_usec / 1000000.
 
-    cpdef uint64_t get_realtime_usec(self):
+    cpdef uint64_t get_realtime_usec(self) -> int:
         return self.realtime_usec
 
-    cpdef uint64_t get_monotonic_usec(self):
+    cpdef uint64_t get_monotonic_usec(self) -> int:
         return self.monotonic_usec
 
     @property
-    def boot_id(self):
+    def boot_id(self) -> UUID:
         return self.__boot_uuid
 
     @property
-    def date(self):
+    def date(self) -> datetime:
         return self.__date
 
     @property
-    def data(self):
+    def data(self) -> dict[str, str]:
         return self._data
 
     def __dealloc__(self):
         PyMem_Free(self.cursor)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<JournalEntry: %r>" % self.date
 
-    def __getitem__(self, str key):
+    def __getitem__(self, str key) -> str:
         return self._data[key]
 
 
@@ -308,20 +309,20 @@ cdef class JournalReader:
         self.state = READER_NULL
         self.flags = None
 
-    def open(self, flags=JournalOpenMode.CURRENT_USER):
+    def open(self, flags=JournalOpenMode.CURRENT_USER) -> int:
         self.flags = JournalOpenMode(int(flags))
 
         with self._lock(opening=True):
-            check_error_code(sd_journal_open(&self.context, self.flags.value))
+            return check_error_code(sd_journal_open(&self.context, self.flags.value))
 
-    def open_directory(self, path):
+    def open_directory(self, path) -> None:
         path = _check_dir_path(path)
 
         with self._lock(opening=True):
             cstr = path.encode()
             check_error_code(sd_journal_open_directory(&self.context, cstr, 0))
 
-    def open_files(self, *file_names):
+    def open_files(self, *file_names) -> None:
         file_names = tuple(map(_check_file_path, file_names))
 
         cdef size_t n = len(file_names)
@@ -339,7 +340,7 @@ cdef class JournalReader:
             PyMem_Free(paths)
 
     @property
-    def data_threshold(self):
+    def data_threshold(self) -> int:
         cdef size_t result
         cdef int rcode
 
@@ -350,7 +351,7 @@ cdef class JournalReader:
         return result
 
     @data_threshold.setter
-    def data_threshold(self, size):
+    def data_threshold(self, size) -> None:
         cdef size_t sz = size
         cdef int result
 
@@ -360,19 +361,19 @@ cdef class JournalReader:
         check_error_code(result)
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self.state == READER_CLOSED
 
     @property
-    def locked(self):
+    def locked(self) -> bool:
         return self.state == READER_LOCKED
 
     @property
-    def idle(self):
+    def idle(self) -> bool:
         return self.state == READER_OPENED
 
     @contextmanager
-    def _lock(self, opening=False):
+    def _lock(self, opening=False) -> None:
         if self.closed:
             raise RuntimeError("Can't lock closed reader")
         elif self.locked:
@@ -387,7 +388,7 @@ cdef class JournalReader:
         finally:
             self.state = READER_OPENED
 
-    def seek_head(self):
+    def seek_head(self) -> bool:
         cdef int result
 
         with self._lock():
@@ -397,16 +398,18 @@ cdef class JournalReader:
 
         return True
 
-    def seek_tail(self):
+    def seek_tail(self) -> bool:
         cdef int result
 
         with self._lock():
             result = sd_journal_seek_tail(self.context)
 
         check_error_code(result)
+        # have to call previous to get the last entry, otherwise it will have an unknown cursor
+        self.previous()
         return True
 
-    def seek_monotonic_usec(self, boot_id: UUID, uint64_t usec):
+    def seek_monotonic_usec(self, boot_id: UUID, uint64_t usec) -> bool:
         cdef sd_id128_t cboot_id
         cdef int result
 
@@ -418,7 +421,7 @@ cdef class JournalReader:
         check_error_code(result)
         return True
 
-    def seek_realtime_usec(self, uint64_t usec):
+    def seek_realtime_usec(self, uint64_t usec) -> bool:
         cdef uint64_t cusec = usec
         cdef int result
 
@@ -428,7 +431,7 @@ cdef class JournalReader:
         check_error_code(result)
         return True
 
-    def seek_cursor(self, bytes cursor):
+    def seek_cursor(self, bytes cursor) -> bool:
         cdef char* ccursor = cursor
         cdef int result
 
@@ -438,7 +441,7 @@ cdef class JournalReader:
         check_error_code(result)
         return True
 
-    cpdef wait(self, uint32_t timeout = WAIT_MAX_TIME):
+    cpdef wait(self, uint32_t timeout = WAIT_MAX_TIME) -> JournalEvent:
         cdef uint64_t timeout_usec = timeout * 1000000
         cdef int result
 
@@ -448,10 +451,10 @@ cdef class JournalReader:
 
         return JournalEvent(check_error_code(result))
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[JournalEntry]:
         return iter(self.next, None)
 
-    def next(self, uint64_t skip=0):
+    def next(self, uint64_t skip=0) -> JournalEntry:
         cdef int result
 
         with self._lock():
@@ -463,7 +466,7 @@ cdef class JournalReader:
             if check_error_code(result) > 0:
                 return JournalEntry(self)
 
-    def skip_next(self, uint64_t skip):
+    def skip_next(self, uint64_t skip) -> int:
         cdef int result
 
         with self._lock():
@@ -471,7 +474,7 @@ cdef class JournalReader:
 
         return check_error_code(result)
 
-    def previous(self, uint64_t skip=0):
+    def previous(self, uint64_t skip=0) -> JournalEntry:
         cdef int result
 
         with self._lock():
@@ -483,7 +486,7 @@ cdef class JournalReader:
             if check_error_code(result) > 0:
                 return JournalEntry(self)
 
-    def skip_previous(self, uint64_t skip):
+    def skip_previous(self, uint64_t skip) -> int:
         cdef int result
 
         with self._lock():
@@ -491,7 +494,7 @@ cdef class JournalReader:
 
         return check_error_code(result)
 
-    def add_filter(self, Rule rule):
+    def add_filter(self, Rule rule) -> None:
         cdef int result
         cdef char* exp
 
@@ -511,10 +514,10 @@ cdef class JournalReader:
                 else:
                     raise ValueError('Invalid operation')
 
-    def clear_filter(self):
+    def clear_filter(self) -> None:
         sd_journal_flush_matches(self.context)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Reader[%s]: %s>" % (
             self.flags, 'closed' if self.closed else 'opened'
         )
@@ -523,23 +526,23 @@ cdef class JournalReader:
         sd_journal_close(self.context)
 
     @property
-    def fd(self):
+    def fd(self) -> int:
         return check_error_code(sd_journal_get_fd(self.context))
 
     @property
-    def events(self):
+    def events(self) -> Poll:
         return Poll(check_error_code(sd_journal_get_events(self.context)))
 
     @property
-    def timeout(self):
+    def timeout(self) -> int:
         cdef uint64_t timeout
         check_error_code(sd_journal_get_timeout(self.context, &timeout))
         return timeout
 
-    def process_events(self):
+    def process_events(self) -> JournalEvent:
         return JournalEvent(check_error_code(sd_journal_process(self.context)))
 
-    def get_catalog(self):
+    def get_catalog(self) -> bytes:
         cdef int result
         cdef char* catalog
         cdef bytes bcatalog
@@ -552,7 +555,7 @@ cdef class JournalReader:
 
         return bcatalog
 
-    def get_catalog_for_message_id(self, message_id):
+    def get_catalog_for_message_id(self, message_id) -> bytes:
         cdef int result
         cdef char* catalog
         cdef bytes bcatalog

--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -163,7 +163,7 @@ cdef enum READER_STATE:
     READER_NULL,
 
 
-cdef str _check_dir_path(object path) -> str:
+cdef str _check_dir_path(object path):
     path = str(path)
 
     if not os.path.exists(path):
@@ -185,7 +185,7 @@ cdef str _check_dir_path(object path) -> str:
     return path
 
 
-cdef str _check_file_path(object path) -> str:
+cdef str _check_file_path(object path):
     path = str(path)
 
     if not os.path.exists(path):

--- a/cysystemd/reader.pyx
+++ b/cysystemd/reader.pyx
@@ -1,5 +1,6 @@
 #cython: unraisable_tracebacks=True
-from typing import Iterator, Tuple
+from pathlib import Path
+from typing import Iterator, Tuple, Union
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.stdint cimport uint8_t, uint32_t, uint64_t
@@ -322,7 +323,7 @@ cdef class JournalReader:
             cstr = path.encode()
             check_error_code(sd_journal_open_directory(&self.context, cstr, 0))
 
-    def open_files(self, *file_names) -> None:
+    def open_files(self, *file_names: Union[str, Path]) -> None:
         file_names = tuple(map(_check_file_path, file_names))
 
         cdef size_t n = len(file_names)
@@ -542,7 +543,7 @@ cdef class JournalReader:
     def process_events(self) -> JournalEvent:
         return JournalEvent(check_error_code(sd_journal_process(self.context)))
 
-    def get_catalog(self) -> bytes:
+    def get_catalog(self) -> Path:
         cdef int result
         cdef char* catalog
         cdef bytes bcatalog
@@ -553,9 +554,9 @@ cdef class JournalReader:
         bcatalog = catalog[:length]
         PyMem_Free(catalog)
 
-        return bcatalog
+        return Path(bcatalog.decode())
 
-    def get_catalog_for_message_id(self, message_id) -> bytes:
+    def get_catalog_for_message_id(self, message_id: UUID) -> Path:
         cdef int result
         cdef char* catalog
         cdef bytes bcatalog
@@ -570,4 +571,4 @@ cdef class JournalReader:
         bcatalog = catalog[:length]
         PyMem_Free(catalog)
 
-        return bcatalog
+        return Path(bcatalog.decode())

--- a/examples/asyncio_reader.py
+++ b/examples/asyncio_reader.py
@@ -8,17 +8,10 @@ from cysystemd.reader import JournalOpenMode
 async def main():
     reader = AsyncJournalReader()
     await reader.open(JournalOpenMode.SYSTEM)
-    await reader.seek_head()
-    # await reader.previous(10)
+    await reader.seek_tail()
 
-    # read all from cursor immediately
     async for record in reader:
         print(json.dumps(record.data, indent=1, sort_keys=True))
-
-    # waiting for new events and print them
-    while await reader.wait():
-        async for record in reader:
-            print(json.dumps(record.data, indent=1, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/scripts/make-wheels.sh
+++ b/scripts/make-wheels.sh
@@ -20,6 +20,7 @@ build_wheel cp39-cp39
 build_wheel cp310-cp310
 build_wheel cp311-cp311
 build_wheel cp312-cp312
+build_wheel cp313-cp313
 
 echo ${VERSION}*linux_${ARCH}
 


### PR DESCRIPTION
Changes:

* Remove complex async iterator queue-based implementation in favor of simpler direct iteration
* Handle journal invalidation by reopening reader and seeking to head
* Yield records only on APPEND events
* Remove unnecessary code and dependencies
* Update documentation example to show simplified usage

BREAKING CHANGE: Changed iterator behavior and removed AsyncReaderIterator class
Bump version to 2.0.0 due to breaking changes


Fixes #65.